### PR TITLE
fix: Add internal modifier at extensions functions

### DIFF
--- a/katadioptre-annotations/src/main/kotlin/io/aerisconsulting/katadioptre/TestableProcessor.kt
+++ b/katadioptre-annotations/src/main/kotlin/io/aerisconsulting/katadioptre/TestableProcessor.kt
@@ -17,6 +17,7 @@ package io.aerisconsulting.katadioptre
 import com.squareup.kotlinpoet.DelicateKotlinPoetApi
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.jvm.jvmName
 import com.squareup.kotlinpoet.metadata.ImmutableKmClass
@@ -139,6 +140,7 @@ internal class TestableProcessor : AbstractProcessor() {
                     .prepareFunctionForProperty(enclosingElement, declaringType, false)
                     .returns(propertyTypeName)
                     .addStatement("return this.getProperty(\"$propertyName\")")
+                    .addModifiers(KModifier.INTERNAL)
                     .build()
             )
         }
@@ -150,6 +152,7 @@ internal class TestableProcessor : AbstractProcessor() {
                     .addParameter("value", propertyTypeName)
                     .addStatement("this.setProperty(\"$propertyName\", value)")
                     .prepareFunctionForProperty(enclosingElement, declaringType, true)
+                    .addModifiers(KModifier.INTERNAL)
                     .build()
             )
         }
@@ -160,6 +163,7 @@ internal class TestableProcessor : AbstractProcessor() {
                 FunSpec.builder("clear" + propertyName.capitalize())
                     .addStatement("this.clearProperty(\"$propertyName\")")
                     .prepareFunctionForProperty(enclosingElement, declaringType, true)
+                    .addModifiers(KModifier.INTERNAL)
                     .build()
             )
         }
@@ -205,6 +209,7 @@ internal class TestableProcessor : AbstractProcessor() {
             .addTypeVariables((kmFunction.typeParameters + declaringType.typeParameters).map {
                 specificationUtils.createTypeNameForTypeParameter(declaringType, it)
             })
+            .addModifiers(KModifier.INTERNAL)
             .returns(function.returnType.asTypeName())
 
         kmFunction.valueParameters.forEach { arg ->


### PR DESCRIPTION
I was having an error using the project as is, when creating the extension methods for internal(or other modifiers) classes, I've got a building error.

So, I've tried to get the exact modifier of the original method to create the extension function using the same, like that: 
Original method:
```
internal class Example{
      @Testable
      private fun test()
}
```

would create a extension function like: 
```
package ....katadioptre

internal Example.test()

```
--
**Another example** 
Original method:
```
protected class Example{
      @Testable
      private fun test()
}
```

would create a extension function like: 
```
package ....katadioptre

protected Example.test()

```

but I had no success, still it looks like that using the `Internal` modifier it can work